### PR TITLE
Fix references to GAP documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ DESIGN, you can find archive files for the package in various formats
 at <https://www.gap-system.org/Packages/design.html>, and then your
 archive file of choice should be downloaded and unpacked in the `pkg'
 subdirectory of an appropriate GAP root directory (see the main GAP
-reference section "Reference: GAP Root Directory").
+reference section "Reference: GAP Root Directories").
 
 The DESIGN package is written entirely in GAP code, and requires
 no further installation.  However, the DESIGN package has complete

--- a/doc/design.tex
+++ b/doc/design.tex
@@ -51,12 +51,12 @@ The {\DESIGN} package is included in the standard {\GAP}~4.5
 distribution. You only need to download and install {\DESIGN} if you need
 to install the package locally or are installing an upgrade of {\DESIGN}
 to an existing installation of {\GAP} (see the main {\GAP} reference
-section "Reference: Installing a GAP Package").  If you do need to download
+section "ref:Installing a GAP Package").  If you do need to download
 {\DESIGN}, you can find archive files for the package in various formats
 at \URL{http://www.gap-system.org/Packages/design.html}, and then your
 archive file of choice should be downloaded and unpacked in the `pkg'
 subdirectory of an appropriate GAP root directory (see the main {\GAP}
-reference section "Reference: GAP Root Directory").
+reference section "ref:GAP Root Directories").
 
 The {\DESIGN} package is written entirely in {\GAP} code, and requires
 no further installation.  However, the {\DESIGN} package has complete

--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -23,7 +23,7 @@
 %F  UseReferences . . . . . . . . . . . . . . . . . .  specify references
 %%
 % \UseReferences{../../../doc/ext}
-% \UseReferences{../../../doc/ref}
+\UseReferences{../../../doc/ref}
 %
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This change fixes broken references to the main GAP reference manual when building the documentation with GAP 4.10.0.