### PR TITLE
Update Travis integration, add .release script

### DIFF
--- a/.release
+++ b/.release
@@ -1,0 +1,4 @@
+#!/bin/sh
+# This file is executed by the `release` script from
+# https://github.com/gap-system/ReleaseTools
+rm -rf .travis.yml .codecov.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,24 @@
 language: c
 env:
   global:
-    - GAPROOT=gaproot
-    - COVDIR=coverage
-    - GAP_PKGS_TO_BUILD="grape"
+    - GAP_PKGS_TO_BUILD="io profiling grape"
 
 addons:
   apt_packages:
     - libgmp-dev
     - libreadline-dev
-    - libgmp-dev:i386
-    - libreadline-dev:i386
-    - gcc-multilib
-    - g++-multilib
+    - zlib1g-dev
 
 matrix:
   include:
-    - env: CFLAGS="-O2" CC=clang CXX=clang++
-      compiler: clang
-    - env: CFLAGS="-O2"
-      compiler: gcc
-    - env: ABI=32
+    - env: GAPBRANCH=master
+    - env: GAPBRANCH=stable-4.10
 
 branches:
   only:
     - master
 
 before_script:
-  - export GAPROOT="$HOME/gap"
   - git clone https://github.com/gap-system/pkg-ci-scripts.git scripts
   - scripts/build_gap.sh
 script:


### PR DESCRIPTION
The .release script is called by ReleaseTools when making a release, and here
is used to remove .travis.yml and .codecov.yml from the release tarball (the
.release script itself is automatically removed).

The Travis integration is fixed to compiled io and profiling; this should fix
coverage reporting on codecov.io