### PR TITLE
PackageInfo.g: remove obsolete BinaryFiles field

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -25,8 +25,6 @@ ArchiveURL      := Concatenation( ~.SourceRepository.URL,
 
 ArchiveFormats := ".tar.gz", 
 
-BinaryFiles := ["doc/manual.dvi", "doc/manual.pdf"],
-
 Persons := [
   rec(
     LastName := "Soicher",


### PR DESCRIPTION
While it is harmless to have it in, there is no point in doing so
