### PR TITLE
Add missing comma to manual.bib

### DIFF
--- a/doc/manual.bib
+++ b/doc/manual.bib
@@ -197,7 +197,7 @@ publisher    = Springer}
 @article{Soi17,
 author	= "Leonard H. Soicher",
 title	= "On classifying objects with specified groups of automorphisms, friendly subgroups, and Sylow tower groups",
-journal	= "Port. Math." 
+journal	= "Port. Math.",
 volume  = "74",
 year    = "2017",
 pages   = "233--242"}


### PR DESCRIPTION
Fixes this error when building documentation for version 1.8.1:
```
This is BibTeX, Version 0.99d (TeX Live 2023)
The top-level auxiliary file: manual.aux
The style file: alpha.bst
Database file #1: manual.bib
I was expecting a `,' or a `}'---line 201 of file manual.bib
 : 
 : volume  = "74",
(Error may have been on previous line)
I'm skipping whatever remains of this entry
(There was 1 error message)
```
